### PR TITLE
Fix uri input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-server-selector",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A component that renders OAS' servers as a dropdown option to select API server.",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepare": "node demo/model.js"
   },
   "dependencies": {
+    "@advanced-rest-client/arc-icons": "^3.0.5",
     "@advanced-rest-client/events-target-mixin": "^3.0.0",
     "@anypoint-web-components/anypoint-dropdown": "^1.0.1",
     "@anypoint-web-components/anypoint-dropdown-menu": "^0.1.14",

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -60,6 +60,10 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
        */
       inline: { type: Boolean },
       /**
+       * If activated, `Custom URI` will not be in the dropdown options
+       */
+      hideCustom: { type: Boolean },
+      /**
        * Holds the current servers to show in in the dropdown menu
        */
       _servers: { type: Array },
@@ -361,6 +365,9 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
    * @return {TemplateResult} Custom URI `anypoint-item`
    */
   renderCustomURIOption() {
+    if (this.hideCustom) {
+      return undefined;
+    }
     return html`<anypoint-item value="custom">Custom URI</anypoint-item>`;
   }
 

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit-element';
+import { html, LitElement, css } from 'lit-element';
 import { AmfHelperMixin } from '@api-components/amf-helper-mixin/amf-helper-mixin.js';
 import { EventsTargetMixin } from '@advanced-rest-client/events-target-mixin/events-target-mixin.js';
 import '@anypoint-web-components/anypoint-input/anypoint-input.js';
@@ -74,6 +74,21 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
   constructor() {
     super();
     this.handleNavigationChange = this.handleNavigationChange.bind(this);
+  }
+
+  get styles() {
+    return css`
+    :host{
+      display: block;
+    }
+
+    .icon {
+      display: inline-block;
+      width: 24px;
+      height: 24px;
+      fill: currentColor;
+    }
+    `;
   }
 
   set servers(value) {
@@ -409,7 +424,8 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
 
   render() {
     const isCustom = this._selectedType === 'custom';
-    return html`<div>
+    return html`<style>${this.styles}</style>
+    <div>
       ${isCustom
         ? this._renderUriInput()
         : this._renderDropdown()}

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -238,7 +238,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
     if (server) {
       return this._getValue(server, '@id');
     }
-    return undefined;
+    return '';
   }
 
   /**
@@ -366,9 +366,9 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
    */
   renderCustomURIOption() {
     if (this.hideCustom) {
-      return undefined;
+      return '';
     }
-    return html`<anypoint-item value="custom">Custom URI</anypoint-item>`;
+    return html`<anypoint-item class="custom-option" value="custom">Custom URI</anypoint-item>`;
   }
 
   /**
@@ -382,7 +382,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
     if (extraOptions) {
       return html`<slot name="api-server-extra-slot"></slot>`;
     }
-    return undefined;
+    return '';
   }
 
   _handleUriChange(event) {

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -365,7 +365,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
   renderExtraSlot() {
     const { extraOptions } = this;
     if (extraOptions) {
-      return html`<slot name="api-server-extra-slot"></slot>`;
+      return html`<slot name="custom-base-uri"></slot>`;
     }
     return '';
   }

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -74,6 +74,18 @@ describe('<api-server-selector>', () => {
       assert.equal(element._selectedIndex, 0);
       assert.equal(element._selectedValue, 'custom');
     });
+
+    it('should unrender uri input when clicking close', () => {
+      const target = { selectedItem: { getAttribute: () => 'custom' } };
+      const detail = {
+        value: 0,
+      };
+      element.handleSelectionChanged({ detail, target });
+      element._resetSelection();
+      assert.equal(element._selectedIndex, undefined);
+      assert.equal(element._selectedValue, undefined);
+      assert.notExists(element.shadowRoot.querySelector('.uri-input'));
+    });
   });
 
   describe('With fixed baseUri', () => {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -86,6 +86,17 @@ describe('<api-server-selector>', () => {
       assert.equal(element._selectedValue, undefined);
       assert.notExists(element.shadowRoot.querySelector('.uri-input'));
     });
+
+    describe('renderCustomURIOption()', () => {
+      it('should return custom uri option', () => {
+        assert.isDefined(element.renderCustomURIOption());
+      });
+
+      it('should not return custom uri option when `hideCustom` is enabled', () => {
+        element.hideCustom = true;
+        assert.isUndefined(element.renderCustomURIOption());
+      });
+    });
   });
 
   describe('With fixed baseUri', () => {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -8,6 +8,10 @@ describe('<api-server-selector>', () => {
     return (await fixture(`<api-server-selector></api-server-selector>`));
   }
 
+  async function hideCustomFixture() {
+    return (await fixture(`<api-server-selector hideCustom></api-server-selector>`));
+  }
+
   async function extraOptionsFixture() {
     return (await fixture(`<api-server-selector extraOptions></api-server-selector>`));
   }
@@ -87,14 +91,24 @@ describe('<api-server-selector>', () => {
       assert.notExists(element.shadowRoot.querySelector('.uri-input'));
     });
 
+    it('should render `Custom URI` option by default', () => {
+      assert.exists(element.shadowRoot.querySelector('.custom-option'));
+    });
+
+    it('should not render `Custom URI` when `hideCustom` is enabled', async () => {
+      element = await hideCustomFixture()
+      await nextFrame();
+      assert.notExists(element.shadowRoot.querySelector('.custom-option'));
+    });
+
     describe('renderCustomURIOption()', () => {
       it('should return custom uri option', () => {
-        assert.isDefined(element.renderCustomURIOption());
+        assert.isNotEmpty(element.renderCustomURIOption());
       });
 
       it('should not return custom uri option when `hideCustom` is enabled', () => {
         element.hideCustom = true;
-        assert.isUndefined(element.renderCustomURIOption());
+        assert.isEmpty(element.renderCustomURIOption());
       });
     });
   });
@@ -295,7 +309,7 @@ describe('<api-server-selector>', () => {
       });
 
       it('should return undefined if no server', () => {
-        assert.isUndefined(element._getServerValue(undefined));
+        assert.isEmpty(element._getServerValue(undefined));
       });
 
       it('should return server id', () => {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -36,36 +36,36 @@ describe('<api-server-selector>', () => {
       assert.exists(element.shadowRoot.querySelector('.api-server-dropdown'));
     });
 
-    it('should not render url input field', () => {
-      assert.notExists(element.shadowRoot.querySelector('.url-input'));
+    it('should not render uri input field', () => {
+      assert.notExists(element.shadowRoot.querySelector('.uri-input'));
     });
 
-    it('should render url input field when any value is selected', async () => {
+    it('should render uri input field when any value is selected', async () => {
       simulateSelection(element, 0, 'custom');
       await nextFrame();
-      assert.exists(element.shadowRoot.querySelector('.url-input'));
+      assert.exists(element.shadowRoot.querySelector('.uri-input'));
     });
 
-    it('should have empty URL', () => {
-      assert.equal(element.url, '');
+    it('should have empty URI', () => {
+      assert.equal(element.uri, '');
     });
 
-    it('should have empty URL field', async () => {
+    it('should have empty URI field', async () => {
       simulateSelection(element, 0, 'custom');
       await nextFrame();
-      assert.isEmpty(element.shadowRoot.querySelector('.url-input').value);
+      assert.isEmpty(element.shadowRoot.querySelector('.uri-input').value);
     });
 
     it('should not render extra slot', () => {
       assert.notExists(element.shadowRoot.querySelector('slot [name="api-server-extra-slot"]'));
     });
 
-    it('should return url after setting it', () => {
-      element.url = 'test url';
-      assert.equal(element.url, 'test url');
+    it('should return uri after setting it', () => {
+      element.uri = 'test uri';
+      assert.equal(element.uri, 'test uri');
     });
 
-    it('should select custom url', () => {
+    it('should select custom uri', () => {
       const target = { selectedItem: { getAttribute: () => 'custom' } };
       const detail = {
         value: 0,
@@ -84,13 +84,13 @@ describe('<api-server-selector>', () => {
       await nextFrame();
     });
 
-    it('should have baseUri as url', () => {
-      assert.equal(element.url, 'https://www.google.com');
+    it('should have baseUri as uri', () => {
+      assert.equal(element.uri, 'https://www.google.com');
     })
 
-    it('should return baseUri as url after setting url', () => {
-      element.url = 'test url';
-      assert.equal(element.url, 'https://www.google.com');
+    it('should return baseUri as uri after setting uri', () => {
+      element.uri = 'test uri';
+      assert.equal(element.uri, 'https://www.google.com');
     })
   });
 
@@ -178,7 +178,7 @@ describe('<api-server-selector>', () => {
         assert.equal(element._selectedIndex, index);
       });
 
-      it('should select custom url', () => {
+      it('should select custom uri', () => {
         const index = element.servers.length;
         simulateSelection(element, index, 'custom');
         assert.equal(element._selectedValue, 'custom');
@@ -219,7 +219,7 @@ describe('<api-server-selector>', () => {
         assert.isUndefined(element._selectedValue);
       });
 
-      it('should update index if custom url is selected and servers change', async () => {
+      it('should update index if custom uri is selected and servers change', async () => {
         element = await basicFixture();
         simulateSelection(element, 0, 'custom');
         element.amf = amf;


### PR DESCRIPTION
Mimic the http-server-selector-mini behavior

- Remove the URI input that always appeared when an option was selected, it was redundant
- Rename instances of URL -> URI
- When Custom URI is selected, change to an editable text input with an X button. Clicking the X returns to the original dropdown of servers, with no value selected