### PR TITLE
Update component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-server-selector",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A component that renders OAS' servers as a dropdown option to select API server.",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -199,7 +199,6 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
     this.dispatchEvent(
       new CustomEvent('api-server-changed', {
         detail: {
-          value,
           selectedValue: value,
           selectedType,
         },

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -171,9 +171,14 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
       return;
     }
     this._uri = value;
+    const selectedType = this.selectedType;
     this.dispatchEvent(
       new CustomEvent('api-server-changed', {
-        detail: { value },
+        detail: { 
+          value,
+          selectedValue: value,
+          selectedType,
+         },
         bubbles: true,
         composed: true,
       }),
@@ -378,8 +383,8 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
     const { styles, isCustom } = this;
     return html`<style>${styles}</style>
     ${isCustom
-      ? this._renderUriInput()
-      : this._renderDropdown()}
+        ? this._renderUriInput()
+        : this._renderDropdown()}
     `;
   }
 

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -63,6 +63,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
       selectedType: { type: String },
       _selectedIndex: { type: Number },
       _selectedValue: { type: String },
+      hidden: { type: Boolean },
     };
   }
 
@@ -75,6 +76,10 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
     return css`
     :host{
       display: block;
+    }
+
+    :host([hidden]) {
+      display: none;
     }
 
     .icon {

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -98,7 +98,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
   }
 
   get servers() {
-    return this._servers;
+    return this._servers || [];
   }
 
   get selected() {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -145,6 +145,24 @@ describe('<api-server-selector>', () => {
         selectedType: 'custom',
       })
     });
+
+    it('should not update selectedValue if selectedType is `server` and it is not an option', async () => {
+      element = await basicFixture();
+      element.selectedType = 'server';
+      element.selectedValue = 'https://example.com';
+      assert.equal(element.selectedType, 'server');
+      assert.isUndefined(element.selectedvalue);
+      assert.isEmpty(element.uri);
+    });
+
+    it('should update selectedValue if selectedType is `custom`', async () => {
+      element = await basicFixture();
+      element.selectedType = 'custom';
+      element.selectedValue = 'https://example.com';
+      assert.equal(element.selectedType, 'custom');
+      assert.equal(element.selectedValue, 'https://example.com');
+      assert.equal(element.uri, 'https://example.com');
+    });
   });
 
   describe('With fixed baseUri', () => {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -413,5 +413,52 @@ describe('<api-server-selector>', () => {
         assert.lengthOf(element.servers, 2);
       });
     });
+
+    describe('_isValueValid()', () => {
+      let amf;
+      let element;
+
+      beforeEach(async () => {
+        amf = await AmfLoader.load(item[1]);
+        element = await basicFixture();
+        element.amf = amf;
+        await nextFrame();
+      });
+
+      it('should return true if `selectedType` is `custom`', () => {
+        element.selectedType = 'custom';
+        assert.isTrue(element._isValueValid());
+      });
+
+      it('should return false if server is not found', () => {
+        assert.isFalse(element._isValueValid('https://www.google.com'));
+      });
+
+      it('should return true if value is found in servers', () => {
+        assert.isTrue(element._isValueValid('https://{customerId}.saas-app.com:{port}/v2'));
+      });
+    });
+
+    describe('_getIndexForValue()', () => {
+      let amf;
+      let element;
+
+      beforeEach(async () => {
+        amf = await AmfLoader.load(item[1]);
+        element = await extraOptionsFixture();
+        element.amf = amf;
+        await nextFrame();
+      });
+
+      it('should return custom value index', async () => {
+        element.selectedType = 'custom';
+        assert.equal(element._getIndexForValue(), 6);
+      });
+
+      it('should return slot value index', async () => {
+        element.selectedType = 'slot';
+        assert.equal(element._getIndexForValue(), 5);
+      });
+    });
   });
 });

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -128,6 +128,23 @@ describe('<api-server-selector>', () => {
         assert.isEmpty(element._renderCustomURIOption());
       });
     });
+
+    it('should dispatch `api-server-changed` event', async () => {
+      element = await baseUriFixture();
+      let event;
+      const handler = (e) => {
+        event = e;
+      }
+      element.addEventListener('api-server-changed', handler);
+      element.selectedType = 'custom';
+      element.uri = 'https://example.com';
+      await nextFrame();
+      assert.deepEqual(event.detail, {
+        value: 'https://example.com',
+        selectedValue: 'https://example.com',
+        selectedType: 'custom',
+      })
+    });
   });
 
   describe('With fixed baseUri', () => {

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -140,7 +140,6 @@ describe('<api-server-selector>', () => {
       element.uri = 'https://example.com';
       await nextFrame();
       assert.deepEqual(event.detail, {
-        value: 'https://example.com',
         selectedValue: 'https://example.com',
         selectedType: 'custom',
       })


### PR DESCRIPTION
- Add `selectedValue` property. When set, the component will check whether the value is valid according to the `selectedType` property, and the available servers in the model (according to navigation selection)
- Dispatch `selectedValue` and `selectedType` in the `api-server-changed` event. `value` will be deprecated, but it is kept for now in case anybody is currently using it
- Rename `extra` selectedType to `slot`