### PR TITLE
feat(autoselect): autoselect first slot if no servers are available

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -1,3 +1,4 @@
 {
-  "demo-api/demo-api.yaml": {"type": "OAS 3.0", "mime": "application/yaml"}
+  "demo-api/demo-api.yaml": {"type": "OAS 3.0", "mime": "application/yaml"},
+  "no-servers-api/no-servers-api.yaml": {"type": "OAS 3.0", "mime": "application/yaml"}
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -188,6 +188,15 @@ class DemoPage extends ApiDemoPage {
       ${this._demoTemplate()}
     `;
   }
+
+  _apiListTemplate() {
+    return [
+      ['demo-api', 'Demo API'],
+      ['no-servers-api', 'No Servers API'],
+    ].map(([file, label]) => html`
+      <anypoint-item data-src="${file}-compact.json">${label} - compact model</anypoint-item>
+      `);
+  }
 }
 
 const instance = new DemoPage();

--- a/demo/no-servers-api/no-servers-api.yaml
+++ b/demo/no-servers-api/no-servers-api.yaml
@@ -1,0 +1,31 @@
+openapi: '3.0.2'
+info:
+  title: Servers demo API
+  version: '1.0'
+
+paths:
+  /default:
+    description: A default path to the API
+    get:
+      summary: "A get method"
+      responses:
+        200:
+          description: Successful response
+  /files:
+    description: File upload and download operations
+    get:
+      summary: "A get method"
+      responses:
+        200:
+          description: Successful response
+  /ping:
+    get:
+      summary: "A get method"
+      responses:
+        200:
+          description: Successful response
+    post:
+      summary: "A post method"
+      responses:
+        201:
+          description: Successful create

--- a/karma.sl.config.js
+++ b/karma.sl.config.js
@@ -10,7 +10,7 @@ module.exports = (config) => {
     },
     client: {
       mocha: {
-        timeout: 10000
+        timeout: 15000
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-server-selector",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A component that renders OAS' servers as a dropdown option to select API server.",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -390,7 +390,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
         this.value = this._getServerUri(srv);
       } else {
         srv = this._getExtraServers()[0];
-        if (srv) {
+        if (srv && this.amf) {
           this.type = 'custom';
           this.value = srv.getAttribute('value');
         }

--- a/src/api-server-selector.js
+++ b/src/api-server-selector.js
@@ -66,7 +66,7 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
       /**
        * When set the `Custom base URI` is rendered in the dropdown
        */
-      allowCustom: { type: Boolean, reflect: true  },
+      allowCustom: { type: Boolean, reflect: true },
 
       /**
        * The current list of servers to render
@@ -376,6 +376,8 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
    * Executes auto selection logic.
    * It selectes a fist available sever from the serves list when AMF or operation
    * selection changed.
+   * If there are no servers, but there are custom slots available, then select
+   * first custom slot
    * When there's already valid selection then it does nothing.
    */
   selectIfNeeded() {
@@ -383,11 +385,17 @@ export class ApiServerSelector extends EventsTargetMixin(AmfHelperMixin(LitEleme
       return;
     }
     if (!this.value) {
-      const srv = this.servers[0];
-      if (!srv) {
-        return;
+      let srv = this.servers[0];
+      if (srv) {
+        this.value = this._getServerUri(srv);
+      } else {
+        srv = this._getExtraServers()[0];
+        if (srv) {
+          this.type = 'custom';
+          this.value = srv.getAttribute('value');
+        }
       }
-      this.value = this._getServerUri(srv);
+
     }
   }
 

--- a/test/api-server-selector.test.js
+++ b/test/api-server-selector.test.js
@@ -102,6 +102,18 @@ describe('<api-server-selector>', () => {
     </api-server-selector>`));
   }
 
+  async function autoSelectFixtureWithSlots(amf) {
+    return await fixture(html`
+      <api-server-selector .amf="${amf}" allowCustom autoSelect>
+        <anypoint-item slot="custom-base-uri" value="http://customServer.com">
+          http://customServer.com
+        </anypoint-item>
+        <anypoint-item slot="custom-base-uri" value="http://customServer2.com">
+          http://customServer2.com
+        </anypoint-item>
+    </api-server-selector>`);
+  }
+
   describe('basic usage', () => {
     it('renders empty dropdown', async () => {
       const element = await basicFixture();
@@ -622,6 +634,31 @@ describe('<api-server-selector>', () => {
           });
           await nextFrame();
           assert.equal(element.value, 'http://beta.api.openweathermap.org/data/2.5/');
+        });
+
+        describe('no servers in model', () => {
+          before(async () => {
+            amf = await AmfLoader.load(compact, 'no-servers-api');
+          });
+
+          after(async () => {
+            amf = await AmfLoader.load(compact);
+          });
+
+          it('selects first slot element if there are no model servers', async () => {
+            const element = await autoSelectFixtureWithSlots(amf);
+            assert.equal(element.value, 'http://customServer.com');
+            assert.equal(element.type, 'custom');
+          });
+
+          it('dispatches slot selection event if there are no model servers', async () => {
+            let detail;
+            addEventListener('apiserverchanged', e => detail = e.detail);
+            await autoSelectFixtureWithSlots(amf);
+            assert.isDefined(detail);
+            assert.equal(detail.value, 'http://customServer.com');
+            assert.equal(detail.type, 'custom');
+          });
         });
       });
 


### PR DESCRIPTION
https://www.mulesoft.org/jira/browse/APIC-399

When auto-selecting, we should take into consideration whether the AMF model has any servers for the node.

If not, we should try to select first custom slot.
We should not, though, if the AMF model is not defined, because this can mean that the model has not loaded yet, and we should not assume anything in this case.